### PR TITLE
don't mix filters

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,25 +27,26 @@ $ sxcs -o --hex | cut -f 2 | xclip -in -selection clipboard
 Color output can be disabled via `--color-none`, which more or less turns
 `sxcs` into a magnifier.
 
-The magnifying window can be customized via using `--mag-filters <filter-list>`,
-where `filter-list` is a comma separated list of filters to apply in order.
+The magnifying window can be customized to have circular border with
+`--broder circle`, or a square border with `--border square`. The grid and
+crosshair can be disabled via `--grid no` and `--crosshair no` respectively.
 
-The default filter list is the following:
+The default filter set in config.h is equivalent to the following:
 
 ```console
-$ sxcs --mag-filters "grid,circle,crosshair_square"
+$ sxcs --grid yes --crosshair yes --border circle
 ```
 
 Following are a couple more examples:
 
 ```console
-$ sxcs --mag-filters "square_border,crosshair_square"
+$ sxcs --grid no --crosshair yes --border square
 ```
 
 <img width="256" height="256" src="preview/square_x.png"/>
 
 ```console
-$ sxcs --mag-filters "grid,crosshair_square"
+$ sxcs --grid yes --crosshair yes --border no
 ```
 
 <img width="256" height="256" src="preview/grid_x.png"/>

--- a/config.def.h
+++ b/config.def.h
@@ -22,19 +22,25 @@ static const uint CIRCLE_WIDTH = 2;
 static const XcursorPixel CIRCLE_COLOR = 0xffff3838;
 static const Bool CIRCLE_TRANSPARENT_OUTSIDE = True;
 
-static const FilterFunc sq_cross[] = {
-	square_border, crosshair_square
+static const FilterSeq sq_cross[] = {
+	NULL,
+	square_border,
+	crosshair_square
 };
 
 static const FilterFunc sq_grid_cross[] = {
-	grid, square_border, crosshair_square
+	grid,
+	square_border,
+	crosshair_square
 };
 
 static const FilterFunc circle_grid_cross[] = {
-	grid, circle, crosshair_square
+	grid,
+	circle,
+	crosshair_square
 };
 
-static const FilterSeq filter_default = FILTER_SEQ_FROM_ARRAY(circle_grid_cross);
+static const FilterSeq filter_default = circle_grid_cross;
 
 /* max time (in ms) allowed to go on without a redraw */
 static const int MAX_FRAME_TIME = 16;


### PR DESCRIPTION
it was possible to set the list of filters in an order which would leave the cursor in a weird state, e.g: `--mag-filters circle,square` or `--mag-filters circle,grid`, so I split the filters in 3 logical categories: grid, border and cross-hair, and draw them appropriately.